### PR TITLE
fix: calls ui apis on main thread

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: objective-c
 matrix:
   include:
-    - osx_image: xcode8.1
+    - osx_image: xcode8.3
 install:
   - gem install jazzy
   - gem install slather

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![GithubForks][img-github-forks]][url-github-forks]
 
 ## Requirements
-* Xcode 8.1 or above
+* Xcode 8.3 or above
 * CocoaPods 1.1.0 or higher
 * MacOS 10.11.5 or higher
 * iOS 9 or higher
@@ -215,7 +215,7 @@ This API can be used only when the user is logged in using Cloud Directory ident
   AppID.sharedInstance.loginWidget?.launchChangePassword(delegate: delegate())
 ```
 
-    
+
 ## Invoking protected resources
 Add the following imports to the file in which you want to invoke a protected resource request:
 ```swift
@@ -248,8 +248,8 @@ This package contains code licensed under the Apache License, Version 2.0 (the "
 [img-github-forks]: https://img.shields.io/github/forks/ibm-cloud-security/appid-clientsdk-swift.svg?style=social&label=Fork
 [url-github-forks]: https://github.com/ibm-cloud-security/appid-clientsdk-swift/network
 
-[img-travis-master]: https://travis-ci.org/ibm-cloud-security/appid-clientsdk-swift.svg
-[url-travis-master]: https://travis-ci.org/ibm-cloud-security/appid-clientsdk-swift
+[img-travis-master]: https://travis-ci.org/ibm-cloud-security/appid-clientsdk-swift.svg?branch=master
+[url-travis-master]: https://travis-ci.org/ibm-cloud-security/appid-clientsdk-swift?branch=master
 
 [img-coveralls-master]: https://coveralls.io/repos/github/ibm-cloud-security/appid-clientsdk-swift/badge.svg
 [url-coveralls-master]: https://coveralls.io/github/ibm-cloud-security/appid-clientsdk-swift

--- a/Source/BluemixAppID/internal/AuthorizationUIManager.swift
+++ b/Source/BluemixAppID/internal/AuthorizationUIManager.swift
@@ -27,21 +27,21 @@ public class AuthorizationUIManager {
         self.authorizationUrl = authorizationUrl
         self.redirectUri = redirectUri
     }
-    
+
     public func launch() {
         AuthorizationUIManager.logger.debug(message: "Launching safari view")
         loginView =  safariView(url: URL(string: authorizationUrl )!)
         loginView?.authorizationDelegate = authorizationDelegate
-        let rootView = UIApplication.shared.keyWindow?.rootViewController
-        let currentView = rootView?.presentedViewController
-        let view = currentView != nil ? currentView : rootView
         DispatchQueue.main.async {
+            let rootView = UIApplication.shared.keyWindow?.rootViewController
+            let currentView = rootView?.presentedViewController
+            let view = currentView != nil ? currentView : rootView
             view?.present(self.loginView!, animated: true, completion:  nil)
         }
     }
-    
+
     public func application(_ application: UIApplication, open url: URL, options :[UIApplicationOpenURLOptionsKey: Any]) -> Bool {
-        
+
         func tokenRequest(code: String?, errMsg:String?) {
             loginView?.dismiss(animated: true, completion: { () -> Void in
                 guard errMsg == nil else {
@@ -53,11 +53,11 @@ public class AuthorizationUIManager {
                     return
                 }
                 AuthorizationUIManager.logger.debug(message: "Obtaining tokens")
-                
+
                 self.oAuthManager.tokenManager?.obtainTokensAuthCode(code: unwrappedCode, authorizationDelegate: self.authorizationDelegate)
             })
         }
-        
+
         if let err = Utils.getParamFromQuery(url: url, paramName: "error") {
             loginView?.dismiss(animated: true, completion: { () -> Void in
                 if err == "invalid_client" {
@@ -104,12 +104,10 @@ public class AuthorizationUIManager {
             }
             return false
         }
-        
+
     }
-    
-    
-    
-    
+
+
+
+
 }
-
-


### PR DESCRIPTION
Closes #123 moving this onto development.

Provides a fix for [#869](https://github.ibm.com/security-services/appid-project-management/issues/869). 

### Issue
Updating UI apis from the background thread results in undefined behavior. This address the problem by moving the calls onto the main queue in the methods async block.

### Testing
Ran a local iOS project using a local pod of BluemixAppID with xcode 9.