### PR TITLE
Returns appropriate message for a pending user

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: objective-c
 matrix:
   include:
-    - osx_image: xcode8.3
+    - osx_image: xcode9.3
 install:
   - gem install jazzy
   - gem install slather
@@ -12,7 +12,7 @@ script:
   - travis_wait pod update
   - pod lib lint --allow-warnings
   - xcodebuild -workspace 'BluemixAppID.xcworkspace' -scheme 'BluemixAppID' clean build CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO
-  - travis_retry xcodebuild -workspace 'BluemixAppID.xcworkspace' test -scheme 'BluemixAppIDTests' -destination 'platform=iOS Simulator,name=iPhone 6' CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -enableCodeCoverage YES
+  - travis_retry xcodebuild -workspace 'BluemixAppID.xcworkspace' test -scheme 'BluemixAppIDTests' -destination 'platform=iOS Simulator,name=iPhone 6' -enableCodeCoverage YES
   - slather coverage --coveralls --binary-basename BluemixAppID.framework -v
   # When merging or pushing to the master branch, release a new version and publish the API documentation
   #- if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_BRANCH}" = "master" ] ; then

--- a/BluemixAppID.xcodeproj/project.pbxproj
+++ b/BluemixAppID.xcodeproj/project.pbxproj
@@ -13,7 +13,7 @@
 		686FA7AB6F9EE8ACF04FFE5B /* Pods_BluemixAppID.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F9518D9FBE5C06EEB62E45B4 /* Pods_BluemixAppID.framework */; };
 		9178A9196CA83023A3A1FC90 /* Pods_BluemixAppIDTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8D5F58BDE9E7A759720873B7 /* Pods_BluemixAppIDTests.framework */; };
 		BDC0D53F1E5EF68300444F9E /* UserAttributeManagerImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC0D53E1E5EF68300444F9E /* UserAttributeManagerImpl.swift */; };
-		BDF5878B1E65736B00393C0C /* (null) in Sources */ = {isa = PBXBuildFile; };
+		BDF5878B1E65736B00393C0C /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		BDF5878F1E66C55A00393C0C /* UserAttributeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF5878E1E66C55A00393C0C /* UserAttributeTests.swift */; };
 		EF3B3BE21E55C4E900DFFF13 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3B3BE11E55C4E900DFFF13 /* AppDelegate.swift */; };
 		EF3B3BE41E55C4E900DFFF13 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3B3BE31E55C4E900DFFF13 /* ViewController.swift */; };
@@ -403,7 +403,6 @@
 				EFBBC7501DF99AFA000CE39A /* Frameworks */,
 				EFBBC7511DF99AFA000CE39A /* Headers */,
 				EFBBC7521DF99AFA000CE39A /* Resources */,
-				B97F0C1B172B2DD0986CA529 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -423,7 +422,6 @@
 				EFBBC7631DF99BF6000CE39A /* Frameworks */,
 				EFBBC7641DF99BF6000CE39A /* Resources */,
 				FF35B93374897FC0DB6A9422 /* [CP] Embed Pods Frameworks */,
-				C602D46B779B62E3A73AB724 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -523,43 +521,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-BluemixAppID-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		B97F0C1B172B2DD0986CA529 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-BluemixAppID/Pods-BluemixAppID-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		C602D46B779B62E3A73AB724 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-BluemixAppIDTests/Pods-BluemixAppIDTests-resources.sh\"\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		E60F8F4C37CAEC13C67E6269 /* [CP] Check Pods Manifest.lock */ = {
@@ -568,13 +539,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-BluemixAppIDTests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		FF35B93374897FC0DB6A9422 /* [CP] Embed Pods Frameworks */ = {
@@ -583,9 +557,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-BluemixAppIDTests/Pods-BluemixAppIDTests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/BMSAnalyticsAPI/BMSAnalyticsAPI.framework",
+				"${BUILT_PRODUCTS_DIR}/BMSCore/BMSCore.framework",
+				"${BUILT_PRODUCTS_DIR}/CryptorRSA/CryptorRSA.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/BMSAnalyticsAPI.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/BMSCore.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CryptorRSA.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -654,7 +635,7 @@
 				EF4994811E55F7BE008ACC27 /* SecurityUtilsTests.swift in Sources */,
 				EF4994821E55F7BE008ACC27 /* AppIDTestConstants.swift in Sources */,
 				EF4994831E55F7BE008ACC27 /* AppIDTests.swift in Sources */,
-				BDF5878B1E65736B00393C0C /* (null) in Sources */,
+				BDF5878B1E65736B00393C0C /* BuildFile in Sources */,
 				EF4994841E55F7BE008ACC27 /* AuthorizationHeaderHelperTests.swift in Sources */,
 				EF4994861E55F7BE008ACC27 /* PreferencesTests.swift in Sources */,
 				EF4994871E55F7BE008ACC27 /* TokenManagerTests.swift in Sources */,

--- a/BluemixAppIDTests/TokenManagerTests.swift
+++ b/BluemixAppIDTests/TokenManagerTests.swift
@@ -416,6 +416,26 @@ class TokenManagerTests: XCTestCase {
         }
     }
     
+    // Pending User Verification
+    func testObtainTokensUsingRop_403_response() {
+        
+        let expectation1 = expectation(description: "got to callback")
+        let err = AppIDError.registrationError(msg: "Failed to register OAuth client")
+        let oauthmanager = OAuthManager(appId: AppID.sharedInstance)
+        oauthmanager.registrationManager?.preferenceManager.getJSONPreference(name: AppIDConstants.registrationDataPref).set([AppIDConstants.client_id_String : TokenManagerTests.clientId])
+        
+        let response:Response = Response(responseData: "{\"error_description\":\"Pending User Verification\", \"error_code\":\"FORBIDDEN\"}".data(using: .utf8), httpResponse: HTTPURLResponse(url: URL(string: "ADS")!, statusCode: 403, httpVersion: nil, headerFields: nil), isRedirect: false)
+        
+        let tokenManager =  MockTokenManagerWithSendRequestRop(oauthManager:oauthmanager, response: response, err: err)
+        tokenManager.obtainTokensRoP(username: "thisisusername", password: "thisispassword",tokenResponseDelegate:  delegate(exp:expectation1, msg: "Pending User Verification"))
+        
+        waitForExpectations(timeout: 1) { error in
+            if let error = error {
+                XCTFail("err: \(error)")
+            }
+        }
+    }
+    
     func testObtainTokensUsingRop_no_400() {
         
         let expectation1 = expectation(description: "got to callback")

--- a/Source/BluemixAppID/api/AuthorizationError.swift
+++ b/Source/BluemixAppID/api/AuthorizationError.swift
@@ -16,7 +16,7 @@ import Foundation
 public enum AuthorizationError: Error {
     case authorizationFailure(String)
     
-    var description: String {
+    public var description: String {
         switch self {
         case .authorizationFailure(let msg) :
             return msg

--- a/Source/BluemixAppID/api/UserAttributeError.swift
+++ b/Source/BluemixAppID/api/UserAttributeError.swift
@@ -15,7 +15,7 @@ import Foundation
 public enum UserAttributeError: Error {
     case userAttributeFailure(String)
 
-    var description: String {
+    public var description: String {
         switch self {
         case .userAttributeFailure(let msg) :
             return msg

--- a/Source/BluemixAppID/internal/TokenManager.swift
+++ b/Source/BluemixAppID/internal/TokenManager.swift
@@ -33,7 +33,7 @@ internal class TokenManager {
         
         guard let clientId = self.registrationManager.getRegistrationDataString(name: AppIDConstants.client_id_String), let redirectUri = self.registrationManager.getRegistrationDataString(arrayName: AppIDConstants.JSON_REDIRECT_URIS_KEY, arrayIndex: 0) else {
             TokenManager.logger.error(message: "Client not registered")
-            authorizationDelegate.onAuthorizationFailure(error: AuthorizationError.authorizationFailure("Client not registered"))
+            authorizationDelegate.onAuthorizationFailure(error: .authorizationFailure("Client not registered"))
             return
         }
         
@@ -78,7 +78,7 @@ internal class TokenManager {
         
         guard let clientId = self.registrationManager.getRegistrationDataString(name: AppIDConstants.client_id_String) else {
             TokenManager.logger.error(message: "Client not registered")
-            tokenResponseDelegate.onAuthorizationFailure(error: AuthorizationError.authorizationFailure("Client not registered"))
+            tokenResponseDelegate.onAuthorizationFailure(error: .authorizationFailure("Client not registered"))
             return
         }
         
@@ -89,7 +89,7 @@ internal class TokenManager {
                        Request.contentType : "application/x-www-form-urlencoded"]
         } catch (_) {
             TokenManager.logger.error(message: "Failed to create authentication header")
-            tokenResponseDelegate.onAuthorizationFailure(error: AuthorizationError.authorizationFailure("Failed to create authentication header"))
+            tokenResponseDelegate.onAuthorizationFailure(error: .authorizationFailure("Failed to create authentication header"))
             return
         }
         
@@ -99,17 +99,18 @@ internal class TokenManager {
                     self.extractTokens(response: unWrappedResponse, tokenResponseDelegate: tokenResponseDelegate)
                 }
                 else {
-                    tokenResponseDelegate.onAuthorizationFailure(error: AuthorizationError.authorizationFailure("Failed to extract tokens"))
+                    tokenResponseDelegate.onAuthorizationFailure(error: .authorizationFailure("Failed to extract tokens"))
                 }
             } else {
                 guard let response = response else {
-                    tokenResponseDelegate.onAuthorizationFailure(error: AuthorizationError.authorizationFailure("Failed to retrieve tokens"))
+                    tokenResponseDelegate.onAuthorizationFailure(error: .authorizationFailure("Failed to retrieve tokens"))
                     return
                 }
                 
                 guard let errorText = response.responseText,
-                    let errorJson = try? Utils.parseJsonStringtoDictionary(errorText) as? [String: String] else {
-                        tokenResponseDelegate.onAuthorizationFailure(error: AuthorizationError.authorizationFailure("Failed to retrieve tokens"))
+                    let errorJson = try? Utils.parseJsonStringtoDictionary(errorText) as? [String: String],
+                    let errorDescription = errorJson?["error_description"] else {
+                        tokenResponseDelegate.onAuthorizationFailure(error: .authorizationFailure("Failed to retrieve tokens"))
                         return
                 }
                 
@@ -117,35 +118,24 @@ internal class TokenManager {
                                                    "Status code: \(response.statusCode ?? -1 ) " +
                                                    "Response: \(errorText)")
                 
-                switch response.statusCode ?? 500 {
-                case 400:
-                    guard errorJson?["error"] == "invalid_grant", let errorDescription = errorJson?["error_description"] else {
-                        fallthrough
-                    }
-                    
-                    tokenResponseDelegate.onAuthorizationFailure(error: AuthorizationError.authorizationFailure(errorDescription))
-                case 403:
-                    guard errorJson?["error_code"] == "FORBIDDEN", let errorDescription = errorJson?["error_description"] else {
-                        fallthrough
-                    }
-                    
-                    tokenResponseDelegate.onAuthorizationFailure(error: AuthorizationError.authorizationFailure(errorDescription))
-                default:
-                    tokenResponseDelegate.onAuthorizationFailure(error: AuthorizationError.authorizationFailure("Failed to retrieve tokens"))
+                if response.statusCode == 400, errorJson?["error"] == "invalid_grant" {
+                    tokenResponseDelegate.onAuthorizationFailure(error: .authorizationFailure(errorDescription))
+                } else if response.statusCode == 403 {
+                    tokenResponseDelegate.onAuthorizationFailure(error: .authorizationFailure(errorDescription))
+                } else {
+                    tokenResponseDelegate.onAuthorizationFailure(error: .authorizationFailure("Failed to retrieve tokens"))
                 }
             }
         }
         
-        let request:Request = Request(url: tokenUrl,method: HttpMethod.POST, headers: headers, queryParameters: nil, timeout: 0)
+        let request = Request(url: tokenUrl,method: HttpMethod.POST, headers: headers, queryParameters: nil, timeout: 0)
         request.timeout = BMSClient.sharedInstance.requestTimeout
         var body = ""
-        var i = 0
-        for (key, val) in bodyParams {
-            body += "\(Utils.urlEncode(key))=\(Utils.urlEncode(val))"
-            if i < bodyParams.count - 1 {
+        for (index, (key: key, value: value)) in bodyParams.enumerated() {
+            body += "\(Utils.urlEncode(key))=\(Utils.urlEncode(value))"
+            if index < bodyParams.count - 1 {
                 body += "&"
             }
-            i += 1
         }
         sendRequest(request: request, body: body.data(using: .utf8), internalCallBack: internalCallback)
 
@@ -162,7 +152,7 @@ internal class TokenManager {
         
         guard let responseText = response.responseText else {
             TokenManager.logger.error(message: "Failed to parse server response - no response text")
-            tokenResponseDelegate.onAuthorizationFailure(error: AuthorizationError.authorizationFailure("Failed to parse server response - no response text"))
+            tokenResponseDelegate.onAuthorizationFailure(error: .authorizationFailure("Failed to parse server response - no response text"))
             return
         }
         do {
@@ -170,12 +160,12 @@ internal class TokenManager {
             
             guard let accessTokenString = (responseJson["access_token"] as? String), let idTokenString = (responseJson["id_token"] as? String) else {
                 TokenManager.logger.error(message: "Failed to parse server response - no access or identity token")
-                tokenResponseDelegate.onAuthorizationFailure(error: AuthorizationError.authorizationFailure("Failed to parse server response - no access or identity token"))
+                tokenResponseDelegate.onAuthorizationFailure(error: .authorizationFailure("Failed to parse server response - no access or identity token"))
                 return
             }
             guard let accessToken = AccessTokenImpl(with: accessTokenString), let identityToken:IdentityTokenImpl = IdentityTokenImpl(with: idTokenString) else {
                 TokenManager.logger.error(message: "Failed to parse tokens")
-                tokenResponseDelegate.onAuthorizationFailure(error: AuthorizationError.authorizationFailure("Failed to parse tokens"))
+                tokenResponseDelegate.onAuthorizationFailure(error: .authorizationFailure("Failed to parse tokens"))
                 return
             }
             let refreshTokenString = responseJson["refresh_token"] as? String
@@ -192,7 +182,7 @@ internal class TokenManager {
                                                          response:response)
         } catch (_) {
             TokenManager.logger.error(message: "Failed to parse server response - failed to parse json")
-            tokenResponseDelegate.onAuthorizationFailure(error: AuthorizationError.authorizationFailure("Failed to parse server response - failed to parse json"))
+            tokenResponseDelegate.onAuthorizationFailure(error: .authorizationFailure("Failed to parse server response - failed to parse json"))
             return
         }
         


### PR DESCRIPTION
Currently, the sdk returns "Token retrieval failed" by default; however, the client application may want to initiate different flows depending on the status of a cloud directory user. 

When a request fails due to incorrect credentials or the user is pending verification, this message is now passed to the client. Additionally, our error description fields should be public for ease of consumption.