### PR TITLE
changing initializer to public

### DIFF
--- a/Source/IBMCloudAppID/api/AppID.swift
+++ b/Source/IBMCloudAppID/api/AppID.swift
@@ -37,7 +37,7 @@ public class AppID {
     static public let REGION_GERMANY = "https://eu-de.appid.cloud.ibm.com"
     static public let REGION_TOKYO = "https://jp-tok.appid.cloud.ibm.com"
 
-    internal init() {}
+    public init() {}
 
     /**
         Intializes the App ID instance


### PR DESCRIPTION
By having the initializer public, multiple App ID instances can be instantiated.
https://github.ibm.com/security-services/appid-project-management/issues/2315