### PR TITLE
fix not working url encoding function in Utils

### DIFF
--- a/IBMCloudAppIDTests/UtilsTests.swift
+++ b/IBMCloudAppIDTests/UtilsTests.swift
@@ -72,6 +72,15 @@ class UtilsTest: XCTestCase {
 //        XCTAssertEqual(dictionary[AppIDConstants.JSON_APPLICATION_VERSION_KEY] as? String, appIdentity.version)
 //        XCTAssertEqual(dictionary[AppIDConstants.JSON_ENVIRONMENT_KEY] as? String, AppIDConstants.JSON_IOS_ENVIRONMENT_VALUE)
 //    }
+
+    func testURLEncoding() {
+        let strToEncode = "test+test@test.com"
+        let exceptedStr = "test%2Btest%40test.com"
+
+        let resultStr = Utils.urlEncode(strToEncode)
+        XCTAssertEqual(resultStr, exceptedStr, "Could not url Encoded")
+    }
+
     func testDecodeBase64WithString() {
         let str = "VGhpcyBpcyBhIFV0aWxzIHVuaXRUZXN0IHR+c/Q="
         let strSafe = "VGhpcyBpcyBhIFV0aWxzIHVuaXRUZXN0IHR-c_Q="

--- a/Source/IBMCloudAppID/internal/RegistrationManager.swift
+++ b/Source/IBMCloudAppID/internal/RegistrationManager.swift
@@ -76,7 +76,7 @@ internal class RegistrationManager {
 
         let request:Request = Request(url: Config.getServerUrl(appId: self.appId) + "/clients",method: HttpMethod.POST, headers: [Request.contentType : "application/json"], queryParameters: nil, timeout: 0)
         request.timeout = BMSClient.sharedInstance.requestTimeout
-        let registrationParamsAsData = try? Utils.urlEncode(Utils.JSONStringify(registrationParams as AnyObject)).data(using: .utf8) ?? Data()
+        let registrationParamsAsData = try? Utils.JSONStringify(registrationParams as AnyObject).data(using: .utf8) ?? Data()
         sendRequest(request: request, registrationParamsAsData: registrationParamsAsData, internalCallBack: internalCallBack)
 
     }

--- a/Source/IBMCloudAppID/internal/Utils.swift
+++ b/Source/IBMCloudAppID/internal/Utils.swift
@@ -226,10 +226,10 @@ public class Utils {
     internal static func urlEncode(_ str:String) -> String{
         var encodedString = ""
         var unchangedCharacters = ""
-        let FORM_ENCODE_SET = " \"':;<=>@[]^`{}|/\\?#&!$(),~%"
+        let FORM_ENCODE_SET = " \"':;<=>@[]^`{}|/\\?#&!$(),~%+".unicodeScalars
 
         for element: Int in 0x20..<0x7f {
-            if !FORM_ENCODE_SET.contains(String(describing: UnicodeScalar(element))) {
+            if !FORM_ENCODE_SET.contains(UnicodeScalar(element)!) {
                 unchangedCharacters += String(Character(UnicodeScalar(element)!))
             }
         }


### PR DESCRIPTION
During our work with the AppID SDK for mobile client we found out that email addresses with plus sign works on Android but not on iOS. For Example the email address test+test@test.de. 
After I analyse the problem, I found out that the function urlEncoding in the Utils didn't work correctly. The returning output string of the function is the same as the input string to the function.
I have fix the problem with a urlEncoding and I had make the change in the RegistrationManager for running the SDK correctly. The JSON which was before given into the urlEncoding function, has no changes make on the JSON, so I have remove this unnessary function call. 